### PR TITLE
Add "host config" to create-container operation

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -100,7 +100,7 @@ module Centurion::Deploy
   end
 
   def start_new_container(server, service, restart_policy)
-    container_config = service.build_config(server.hostname, &hostname_proc)
+    container_config = service.build_config(server.hostname, restart_policy, &hostname_proc)
     info "Creating new container for #{container_config['Image']}"
     container = server.create_container(container_config, service.name)
 

--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -71,6 +71,7 @@ class Centurion::DockerViaApi
 
   def create_container(configuration, name = nil)
     path = @docker_api_version + "/containers/create"
+
     response = with_excon do |e|
       e.post(
         path: path,

--- a/lib/centurion/service.rb
+++ b/lib/centurion/service.rb
@@ -103,7 +103,7 @@ module Centurion
       @security_opt << seccomp
     end
 
-    def build_config(server_hostname, &block)
+    def build_config(server_hostname, restart_policy, &block)
       container_config = {}.tap do |c|
         c['Image'] = image
         c['Hostname'] = block.call(server_hostname) if block_given?
@@ -136,6 +136,8 @@ module Centurion
           memo
         end
       end
+
+      container_config['HostConfig'] = build_host_config(restart_policy)
 
       container_config
     end


### PR DESCRIPTION
Diff in container specs between a broken s4-service and a fixed s4-service deployed with this change
```
3,4c3,4
<         "Id": "300f83ad167a65b67cb83612534ced99c5cfa1aaf2a9fa247a7e6f027c28b57a",
<         "Created": "2024-05-26T23:49:33.107543283Z",
---
>         "Id": "8833c1a5d538fd40c2a09bfe4a65f0237bb8c6e8396ce14d1c2947617d11971b",
>         "Created": "2024-05-27T00:07:08.925697801Z",
18c18
<             "Pid": 2497564,
---
>             "Pid": 2497736,
21c21
<             "StartedAt": "2024-05-26T23:49:33.527629678Z",
---
>             "StartedAt": "2024-05-27T00:07:09.205161203Z",
25,29c25,29
<         "ResolvConfPath": "/var/lib/docker/containers/300f83ad167a65b67cb83612534ced99c5cfa1aaf2a9fa247a7e6f027c28b57a/resolv.conf",
<         "HostnamePath": "/var/lib/docker/containers/300f83ad167a65b67cb83612534ced99c5cfa1aaf2a9fa247a7e6f027c28b57a/hostname",
<         "HostsPath": "/var/lib/docker/containers/300f83ad167a65b67cb83612534ced99c5cfa1aaf2a9fa247a7e6f027c28b57a/hosts",
<         "LogPath": "/var/lib/docker/containers/300f83ad167a65b67cb83612534ced99c5cfa1aaf2a9fa247a7e6f027c28b57a/300f83ad167a65b67cb83612534ced99c5cfa1aaf2a9fa247a7e6f027c28b57a-json.log",
<         "Name": "/s4-service-87af5d85714600",
---
>         "ResolvConfPath": "/var/lib/docker/containers/8833c1a5d538fd40c2a09bfe4a65f0237bb8c6e8396ce14d1c2947617d11971b/resolv.conf",
>         "HostnamePath": "/var/lib/docker/containers/8833c1a5d538fd40c2a09bfe4a65f0237bb8c6e8396ce14d1c2947617d11971b/hostname",
>         "HostsPath": "/var/lib/docker/containers/8833c1a5d538fd40c2a09bfe4a65f0237bb8c6e8396ce14d1c2947617d11971b/hosts",
>         "LogPath": "/var/lib/docker/containers/8833c1a5d538fd40c2a09bfe4a65f0237bb8c6e8396ce14d1c2947617d11971b/8833c1a5d538fd40c2a09bfe4a65f0237bb8c6e8396ce14d1c2947617d11971b-json.log",
>         "Name": "/s4-service-2c1e5a1a855395",
38c38,43
<             "Binds": null,
---
>             "Binds": [
>                 "/home/mooveit/.ssh:/root/.ssh",
>                 "/var/log/bancard.s4.service:/home/bancard-s4-service/log",
>                 "/var/log/thin/bancard.s4.service:/var/log/thin",
>                 "/usr/local/src/bancard-s4-static-store:/bancard-s4-static-store"
>             ],
44,45c49,50
<             "NetworkMode": "bridge",
<             "PortBindings": null,
---
>             "NetworkMode": "host",
>             "PortBindings": {},
47c52
<                 "Name": "no",
---
>                 "Name": "unless-stopped",
57,58c62,63
<             "CapAdd": null,
<             "CapDrop": null,
---
>             "CapAdd": [],
>             "CapDrop": [],
131,134c136,139
<                 "LowerDir": "/var/lib/docker/overlay2/1ca809ae2bd326fcdd6f470dbfb0d05ba7af8bff563dc03f8d7a9432a1522a0c-init/diff:/var/lib/docker/overlay2/07a369e4a4143b9089414104cd2e2f0def1d42f06541d810f39ffdb987630f09/diff:/var/lib/docker/overlay2/84547d09727a7ec4217eadfd16856d368bb3b3b7999c4aa8a6ac12dcbd6fff52/diff:/var/lib/docker/overlay2/43855c11ff5a61ba3a942317f1500302cdba212d6363552223dbac0d3a3972d9/diff:/var/lib/docker/overlay2/8c0bd19c0de40aeeae7b5881a7e380d588bdf02406c86b4c3128681e9bfb1426/diff:/var/lib/docker/overlay2/8c36376e4476395e99e50110abf5a12d855900725900fef4bbee561f90d95be4/diff:/var/lib/docker/overlay2/ad01b65cbf376ea74805b0921c477c5a9231152c8d8b76bc40a7e6d2102c62d1/diff:/var/lib/docker/overlay2/ae70b3090065b4ea4fb3b19f99a5885d6c776fe073161980c10987c588d2e1ac/diff:/var/lib/docker/overlay2/129e71db48e395bd21593717c8824e59d4a6399b5252173947b10eb69d63f956/diff:/var/lib/docker/overlay2/573b62d64ad0045f2af9288ca17c165ce3b6d83516b2ede2b75d6e6a35b8c412/diff:/var/lib/docker/overlay2/f465149062689b2509c912a7bb0139faa773f9916f5d58db2e16b1362935355b/diff:/var/lib/docker/overlay2/907c26d47bda6424f58c4eb604ec52a3aa4e21106800e9605fb85ba3c50b7ab8/diff:/var/lib/docker/overlay2/6501323fe885aaf3195d970dd562be486f51b79179c29a4fd99178b4bb97f771/diff:/var/lib/docker/overlay2/3845ccd8812044fa370b5b3ef2061ac98c9b573b1768b68d5facde234f0a601c/diff:/var/lib/docker/overlay2/bc6014c6af3345c77717652a865cc903f82c79bf7be3c2d2dd246f5dce3af2e8/diff:/var/lib/docker/overlay2/17fa8d3434647ba77271e0208103c64e7a3c29ba3e7cde7357a18b649b64882c/diff:/var/lib/docker/overlay2/98b270b6bc3aeb63b6b658dd10b0997311e4e8c9081a348c99fc01315c63efd5/diff",
<                 "MergedDir": "/var/lib/docker/overlay2/1ca809ae2bd326fcdd6f470dbfb0d05ba7af8bff563dc03f8d7a9432a1522a0c/merged",
<                 "UpperDir": "/var/lib/docker/overlay2/1ca809ae2bd326fcdd6f470dbfb0d05ba7af8bff563dc03f8d7a9432a1522a0c/diff",
<                 "WorkDir": "/var/lib/docker/overlay2/1ca809ae2bd326fcdd6f470dbfb0d05ba7af8bff563dc03f8d7a9432a1522a0c/work"
---
>                 "LowerDir": "/var/lib/docker/overlay2/9d24d31fb3c848911421b1531b942a6f339435df67a599479d048048ab995283-init/diff:/var/lib/docker/overlay2/07a369e4a4143b9089414104cd2e2f0def1d42f06541d810f39ffdb987630f09/diff:/var/lib/docker/overlay2/84547d09727a7ec4217eadfd16856d368bb3b3b7999c4aa8a6ac12dcbd6fff52/diff:/var/lib/docker/overlay2/43855c11ff5a61ba3a942317f1500302cdba212d6363552223dbac0d3a3972d9/diff:/var/lib/docker/overlay2/8c0bd19c0de40aeeae7b5881a7e380d588bdf02406c86b4c3128681e9bfb1426/diff:/var/lib/docker/overlay2/8c36376e4476395e99e50110abf5a12d855900725900fef4bbee561f90d95be4/diff:/var/lib/docker/overlay2/ad01b65cbf376ea74805b0921c477c5a9231152c8d8b76bc40a7e6d2102c62d1/diff:/var/lib/docker/overlay2/ae70b3090065b4ea4fb3b19f99a5885d6c776fe073161980c10987c588d2e1ac/diff:/var/lib/docker/overlay2/129e71db48e395bd21593717c8824e59d4a6399b5252173947b10eb69d63f956/diff:/var/lib/docker/overlay2/573b62d64ad0045f2af9288ca17c165ce3b6d83516b2ede2b75d6e6a35b8c412/diff:/var/lib/docker/overlay2/f465149062689b2509c912a7bb0139faa773f9916f5d58db2e16b1362935355b/diff:/var/lib/docker/overlay2/907c26d47bda6424f58c4eb604ec52a3aa4e21106800e9605fb85ba3c50b7ab8/diff:/var/lib/docker/overlay2/6501323fe885aaf3195d970dd562be486f51b79179c29a4fd99178b4bb97f771/diff:/var/lib/docker/overlay2/3845ccd8812044fa370b5b3ef2061ac98c9b573b1768b68d5facde234f0a601c/diff:/var/lib/docker/overlay2/bc6014c6af3345c77717652a865cc903f82c79bf7be3c2d2dd246f5dce3af2e8/diff:/var/lib/docker/overlay2/17fa8d3434647ba77271e0208103c64e7a3c29ba3e7cde7357a18b649b64882c/diff:/var/lib/docker/overlay2/98b270b6bc3aeb63b6b658dd10b0997311e4e8c9081a348c99fc01315c63efd5/diff",
>                 "MergedDir": "/var/lib/docker/overlay2/9d24d31fb3c848911421b1531b942a6f339435df67a599479d048048ab995283/merged",
>                 "UpperDir": "/var/lib/docker/overlay2/9d24d31fb3c848911421b1531b942a6f339435df67a599479d048048ab995283/diff",
>                 "WorkDir": "/var/lib/docker/overlay2/9d24d31fb3c848911421b1531b942a6f339435df67a599479d048048ab995283/work"
140,142c145,146
<                 "Type": "volume",
<                 "Name": "c490bab663ac8bfd874f8eb2edfcfcf7bbe9579e0ae6ba8a3ffc31ea4da5c8ac",
<                 "Source": "/var/lib/docker/volumes/c490bab663ac8bfd874f8eb2edfcfcf7bbe9579e0ae6ba8a3ffc31ea4da5c8ac/_data",
---
>                 "Type": "bind",
>                 "Source": "/home/mooveit/.ssh",
144d147
<                 "Driver": "local",
147c150
<                 "Propagation": ""
---
>                 "Propagation": "rprivate"
150,152c153,154
<                 "Type": "volume",
<                 "Name": "a40c51078e18663cb79efe259d9a07204f46412502ec5c4dcd736681cc12a1b9",
<                 "Source": "/var/lib/docker/volumes/a40c51078e18663cb79efe259d9a07204f46412502ec5c4dcd736681cc12a1b9/_data",
---
>                 "Type": "bind",
>                 "Source": "/var/log/bancard.s4.service",
154d155
<                 "Driver": "local",
157c158
<                 "Propagation": ""
---
>                 "Propagation": "rprivate"
160,162c161,162
<                 "Type": "volume",
<                 "Name": "83af152043d26d314aef50e395f5de00ce66517a0b8d51de85235a9c45e2f516",
<                 "Source": "/var/lib/docker/volumes/83af152043d26d314aef50e395f5de00ce66517a0b8d51de85235a9c45e2f516/_data",
---
>                 "Type": "bind",
>                 "Source": "/var/log/thin/bancard.s4.service",
164d163
<                 "Driver": "local",
167c166
<                 "Propagation": ""
---
>                 "Propagation": "rprivate"
170,172c169,170
<                 "Type": "volume",
<                 "Name": "d2770fa981404814cfb0227e43644e8f43390585ebd269aef0b081885e209dfc",
<                 "Source": "/var/lib/docker/volumes/d2770fa981404814cfb0227e43644e8f43390585ebd269aef0b081885e209dfc/_data",
---
>                 "Type": "bind",
>                 "Source": "/usr/local/src/bancard-s4-static-store",
174d171
<                 "Driver": "local",
177c174
<                 "Propagation": ""
---
>                 "Propagation": "rprivate"
181c178
<             "Hostname": "300f83ad167a",
---
>             "Hostname": "qa-srv-tes-05.infrabc.dom",
225,226c222,223
<             "SandboxID": "362a79c3042729c86c91170b359dd36463c6e1e05ab4aa00951b55367ce7df70",
<             "SandboxKey": "/var/run/docker/netns/362a79c30427",
---
>             "SandboxID": "d48702e51f96399b08086ce69a33f0905222275f6c2dda03d9aa04508c1e7124",
>             "SandboxKey": "/var/run/docker/netns/default",
233,234c230,231
<             "EndpointID": "2621151806d878793841aebe1eae36c3672d886c54b9d234f7092d6bd70bfa8a",
<             "Gateway": "172.17.0.1",
---
>             "EndpointID": "",
>             "Gateway": "",
237,238c234,235
<             "IPAddress": "172.17.0.3",
<             "IPPrefixLen": 16,
---
>             "IPAddress": "",
>             "IPPrefixLen": 0,
240c237
<             "MacAddress": "02:42:ac:11:00:03",
---
>             "MacAddress": "",
242c239
<                 "bridge": {
---
>                 "host": {
246,251c243,248
<                     "MacAddress": "02:42:ac:11:00:03",
<                     "NetworkID": "f716ddcb1866a7b8dd4d940150b57af49cadad7145c2d8ef430e7c274e96de7c",
<                     "EndpointID": "2621151806d878793841aebe1eae36c3672d886c54b9d234f7092d6bd70bfa8a",
<                     "Gateway": "172.17.0.1",
<                     "IPAddress": "172.17.0.3",
<                     "IPPrefixLen": 16,
---
>                     "MacAddress": "",
>                     "NetworkID": "0fd31da67970e9dccd48a487e070e671e4db5d3e938b6870beb05264754da0a2",
>                     "EndpointID": "31d92c58430027183dcfd80f1ca00a540a37d119e33ff4374a3085da284ce588",
>                     "Gateway": "",
>                     "IPAddress": "",
>                     "IPPrefixLen": 0,
```